### PR TITLE
platformio: Erase OTA partition before upload

### DIFF
--- a/eraseOTA.py
+++ b/eraseOTA.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+"""
+Erases the OTA partition before flashing, this ensures that the software flashed
+via USB will be booted and not an older OTA version.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+Import("env")  # pylint: disable=undefined-variable
+
+
+def before_upload(source, target, env):
+    """Remove the OTA partition before uploading a new firmware"""
+
+    print("Performing pre-upload erase of OTA partition...")
+
+    idf_path = Path(env.PioPlatform().get_package_dir("framework-espidf"))
+    os.environ["IDF_PATH"] = str(idf_path)
+    otatool_path = idf_path / "components" / "app_update"
+    parttool_path = idf_path / "components" / "partition_table"
+    sys.path.extend([str(otatool_path), str(parttool_path)])
+
+    from otatool import (  # pylint: disable=import-error,import-outside-toplevel
+        OtatoolTarget,
+    )
+
+    ota_target = OtatoolTarget(env.subst("$UPLOAD_PORT"))
+    ota_target.erase_otadata()
+
+
+env.AddPreAction("upload", before_upload)  # pylint: disable=undefined-variable

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,7 @@ monitor_speed = 115200
 extra_scripts =
     pre:gitVersion.py
     pre:processHtml.py
+    post:eraseOTA.py
 lib_deps =
 	https://github.com/schreibfaul1/ESP32-audioI2S.git
 	https://github.com/madhephaestus/ESP32Encoder.git#22992b3
@@ -45,6 +46,8 @@ platform_packages =
     ;platformio/framework-arduinoespressif32 @ https://github.com/tuniii/arduino-esp32-v1.0.6-wt#v1.0.6-patched
     ;platformio/tool-esptoolpy @ ~1.30100
     ;framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.1-RC1
+    ; For tools such as otatool.py and parttool.py
+    platformio/framework-espidf@3.40001.200521
 
 [env:esp32-a1s]
 board = esp-wrover-kit


### PR DESCRIPTION
Erases the OTA partition before flashing, this ensures that the software flashed via USB will be booted and not an older OTA version.